### PR TITLE
Substitution of symbol to identifier

### DIFF
--- a/parser.rkt
+++ b/parser.rkt
@@ -5,11 +5,11 @@ OB < '(' ;
 CB < ')' ;
 DQ < ["] ;
 
-s-exp <- atom / list / quote / quasiquote / unquote ;
-atom <- boolean / symbol / number / string ;
+s-exp <-  list / quote / quasiquote / unquote  / atom;
+atom <- boolean / number / identifier/ string ;
 list <-- OB _ (s-exp _)*  CB ;
 boolean <-- '#t' / '#f' ;
-symbol <-- [a-zA-Z\-]+ ;
+identifier <--   [^ ()\[\]{}",'`;#|\\]+ ;
 number <-- [0-9]+ ;
 string <-- DQ [^"]* DQ ;
 


### PR DESCRIPTION
Now we can match `(+ 1 2)` as a list of `+` and 1 and 2.

I use the identifier's definition of racket