### PR TITLE
modify symbol to identifier

### DIFF
--- a/parser.rkt
+++ b/parser.rkt
@@ -5,11 +5,11 @@ OB < '(' ;
 CB < ')' ;
 DQ < ["] ;
 
-s-exp <- atom / list / quote / quasiquote / unquote ;
-atom <- boolean / symbol / number / string ;
+s-exp <-  list / quote / quasiquote / unquote  / atom;
+atom <- boolean / number / identifier/ string ;
 list <-- OB _ (s-exp _)*  CB ;
 boolean <-- '#t' / '#f' ;
-symbol <-- [a-zA-Z\-]+ ;
+identifier <--   [^ ()\[\]{}",'`;#|\\]+ ;
 number <-- [0-9]+ ;
 string <-- DQ [^"]* DQ ;
 

--- a/transformer.rkt
+++ b/transformer.rkt
@@ -12,7 +12,7 @@
     (`(boolean . "#t") #t)
     (`(boolean . "#f") #f)
 
-    (`(symbol . ,s) (string->symbol s))
+    (`(identifier . ,s) (string->symbol s))
 
     (`(number . ,n) (string->number n))
 


### PR DESCRIPTION
Now we have the peg of `(+ 1 2)` accepted.

I use the definition of identifier of racket, except some little things, like `.` be allowed only if not alone and things like this that we can, if necessary, add in the future.

The thing that I put cover 99%+ of cases.